### PR TITLE
feat: recreate website in Next.js (story #67)

### DIFF
--- a/nextjs-site/.eslintrc.json
+++ b/nextjs-site/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals"]
+}

--- a/nextjs-site/README.md
+++ b/nextjs-site/README.md
@@ -1,0 +1,26 @@
+# yizijun-site Next.js recreation
+
+This directory contains a Next.js recreation of the existing website requested in issue #67.
+
+## Run locally
+
+```bash
+npm install
+npm run dev
+```
+
+Open http://localhost:3000
+
+## Build for production
+
+```bash
+npm run build
+npm run start
+```
+
+## Routes
+
+- `/` Home (WELCOME, Games/Portfolio navigation)
+- `/portfolio` Portfolio overview sections
+- `/games` Games landing
+- `/games/snake` Snake mini-game

--- a/nextjs-site/next-env.d.ts
+++ b/nextjs-site/next-env.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />

--- a/nextjs-site/next.config.js
+++ b/nextjs-site/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+module.exports = nextConfig;

--- a/nextjs-site/package.json
+++ b/nextjs-site/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "yizijun-site-nextjs",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.2.12",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "typescript": "5.6.3",
+    "@types/node": "22.7.5",
+    "@types/react": "18.3.11",
+    "@types/react-dom": "18.3.0",
+    "eslint": "8.57.1",
+    "eslint-config-next": "14.2.12"
+  }
+}

--- a/nextjs-site/src/app/games/page.tsx
+++ b/nextjs-site/src/app/games/page.tsx
@@ -1,0 +1,16 @@
+import Link from 'next/link';
+
+export default function GamesPage() {
+  return (
+    <section className="page">
+      <h1>Games</h1>
+      <p>Mini-games recreated from the original site navigation.</p>
+      <div className="grid">
+        <Link className="panel link" href="/games/snake">
+          <h3>Snake</h3>
+          <p>Canvas-based snake game route in Next.js.</p>
+        </Link>
+      </div>
+    </section>
+  );
+}

--- a/nextjs-site/src/app/games/snake/page.tsx
+++ b/nextjs-site/src/app/games/snake/page.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useEffect, useRef, useState } from 'react';
+
+type Point = { x: number; y: number };
+const CELL = 20;
+const SIZE = 20;
+
+export default function SnakePage() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [score, setScore] = useState(0);
+
+  useEffect(() => {
+    let snake: Point[] = [{ x: 8, y: 8 }];
+    let dir: Point = { x: 1, y: 0 };
+    let food: Point = { x: 14, y: 10 };
+    let alive = true;
+
+    const randomCell = (): Point => ({
+      x: Math.floor(Math.random() * SIZE),
+      y: Math.floor(Math.random() * SIZE),
+    });
+
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'ArrowUp' && dir.y !== 1) dir = { x: 0, y: -1 };
+      if (e.key === 'ArrowDown' && dir.y !== -1) dir = { x: 0, y: 1 };
+      if (e.key === 'ArrowLeft' && dir.x !== 1) dir = { x: -1, y: 0 };
+      if (e.key === 'ArrowRight' && dir.x !== -1) dir = { x: 1, y: 0 };
+    };
+
+    window.addEventListener('keydown', onKey);
+
+    const tick = setInterval(() => {
+      if (!alive) return;
+      const head = { x: snake[0].x + dir.x, y: snake[0].y + dir.y };
+      if (head.x < 0 || head.y < 0 || head.x >= SIZE || head.y >= SIZE || snake.some((p) => p.x === head.x && p.y === head.y)) {
+        alive = false;
+        return;
+      }
+      snake = [head, ...snake];
+      if (head.x === food.x && head.y === food.y) {
+        setScore((s) => s + 1);
+        food = randomCell();
+      } else {
+        snake.pop();
+      }
+
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+      const ctx = canvas.getContext('2d');
+      if (!ctx) return;
+      ctx.fillStyle = '#0f172a';
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+      ctx.fillStyle = '#f43f5e';
+      ctx.fillRect(food.x * CELL, food.y * CELL, CELL - 2, CELL - 2);
+
+      ctx.fillStyle = '#22c55e';
+      snake.forEach((p) => ctx.fillRect(p.x * CELL, p.y * CELL, CELL - 2, CELL - 2));
+
+      if (!alive) {
+        ctx.fillStyle = 'white';
+        ctx.font = '24px sans-serif';
+        ctx.fillText('Game Over', 130, 200);
+      }
+    }, 110);
+
+    return () => {
+      clearInterval(tick);
+      window.removeEventListener('keydown', onKey);
+    };
+  }, []);
+
+  return (
+    <section className="page">
+      <h1>Snake</h1>
+      <p>Use arrow keys to play. Score: {score}</p>
+      <canvas ref={canvasRef} width={400} height={400} className="snake-canvas" />
+    </section>
+  );
+}

--- a/nextjs-site/src/app/globals.css
+++ b/nextjs-site/src/app/globals.css
@@ -1,0 +1,40 @@
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: Inter, system-ui, Arial, sans-serif;
+  background: radial-gradient(circle at top, #1f2937, #0b1020);
+  color: #e5e7eb;
+}
+.site-header {
+  border-bottom: 1px solid #334155;
+  position: sticky;
+  top: 0;
+  background: rgba(7, 10, 20, 0.9);
+  backdrop-filter: blur(6px);
+}
+.nav {
+  max-width: 980px;
+  margin: 0 auto;
+  padding: 14px 16px;
+  display: flex;
+  gap: 18px;
+}
+.nav a { color: #93c5fd; text-decoration: none; font-weight: 600; }
+main { max-width: 980px; margin: 0 auto; padding: 24px 16px 60px; }
+.hero { text-align: center; padding: 80px 0; }
+.hero h1 { font-size: 3rem; margin-bottom: 0.2rem; }
+.hero p { color: #cbd5e1; margin-bottom: 2rem; }
+.cta-row { display: flex; justify-content: center; gap: 16px; }
+.card, .panel.link {
+  text-decoration: none;
+  color: #e2e8f0;
+  border: 1px solid #334155;
+  background: #111827;
+  border-radius: 12px;
+  padding: 16px 24px;
+  display: inline-block;
+}
+.page h1 { margin-top: 8px; }
+.grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 16px; margin-top: 20px; }
+.panel { border: 1px solid #334155; background: #0f172a; border-radius: 12px; padding: 16px; }
+.snake-canvas { border: 1px solid #334155; background: #0f172a; border-radius: 8px; }

--- a/nextjs-site/src/app/layout.tsx
+++ b/nextjs-site/src/app/layout.tsx
@@ -1,0 +1,25 @@
+import './globals.css';
+import Link from 'next/link';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: "Yizijun's Website",
+  description: 'Recreated with Next.js',
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <header className="site-header">
+          <nav className="nav">
+            <Link href="/">Home</Link>
+            <Link href="/portfolio">Portfolio</Link>
+            <Link href="/games">Games</Link>
+          </nav>
+        </header>
+        <main>{children}</main>
+      </body>
+    </html>
+  );
+}

--- a/nextjs-site/src/app/page.tsx
+++ b/nextjs-site/src/app/page.tsx
@@ -1,0 +1,14 @@
+import Link from 'next/link';
+
+export default function HomePage() {
+  return (
+    <section className="hero">
+      <h1>Yizijun&apos;s Website</h1>
+      <p>WELCOME</p>
+      <div className="cta-row">
+        <Link className="card" href="/games">GAMES</Link>
+        <Link className="card" href="/portfolio">PORTFOLIO</Link>
+      </div>
+    </section>
+  );
+}

--- a/nextjs-site/src/app/portfolio/page.tsx
+++ b/nextjs-site/src/app/portfolio/page.tsx
@@ -1,0 +1,25 @@
+const items = [
+  { title: 'Bio', text: 'Student at Syracuse University, Information Management & Technology.' },
+  { title: 'Application Letter', text: 'Professional writing sample and communication portfolio artifact.' },
+  { title: 'Memo', text: 'Business memo sample demonstrating concise professional writing.' },
+  { title: 'Research', text: 'Academic and project research excerpts from coursework.' },
+  { title: 'Projects', text: 'Web and software projects built across internships and school.' },
+  { title: 'Contact', text: 'Social links and contact channels from original site.' },
+];
+
+export default function PortfolioPage() {
+  return (
+    <section className="page">
+      <h1>Online Portfolio</h1>
+      <p>This page recreates the portfolio structure from the original website.</p>
+      <div className="grid">
+        {items.map((item) => (
+          <article className="panel" key={item.title}>
+            <h3>{item.title}</h3>
+            <p>{item.text}</p>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/nextjs-site/tsconfig.json
+++ b/nextjs-site/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next"}],
+    "paths": {"@/*": ["./src/*"]}
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
Implements story #67 by introducing a Next.js recreation in nextjs-site/ with routes for home, portfolio, games, and snake.

## Notes
Node/npm are not installed in this environment, so build/test commands could not be run here.

Closes #67