### PR TITLE
ci(cd): simplify deployment by switching to GitHub Pages

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,33 +1,55 @@
-name: CD
+name: Deploy to GitHub Pages
 
 on:
   push:
     branches: [master]
+  workflow_dispatch:
 
 permissions:
   contents: read
-  packages: write
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
 
 jobs:
-  build-and-push-image:
+  build:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: nextjs-site
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Login to GHCR
-        uses: docker/login-action@v3
+      - name: Setup Node
+        uses: actions/setup-node@v4
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          node-version: 20
 
-      - name: Build and push image
-        uses: docker/build-push-action@v6
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build static export
+        run: npm run build
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          context: .
-          file: ./dockerfile
-          push: true
-          tags: |
-            ghcr.io/${{ github.repository }}:${{ github.sha }}
-            ghcr.io/${{ github.repository }}:latest
+          path: nextjs-site/out
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/nextjs-site/README.md
+++ b/nextjs-site/README.md
@@ -18,6 +18,16 @@ npm run build
 npm run start
 ```
 
+## GitHub Pages deployment
+
+This project deploys with GitHub Actions via `.github/workflows/cd.yml`.
+
+- CD publishes the static export from `nextjs-site/out`.
+- `next.config.js` is configured for static export and repo base path on GitHub Actions.
+
+Repository settings requirement:
+- In **Settings → Pages**, set **Source** to **GitHub Actions**.
+
 ## Routes
 
 - `/` Home (WELCOME, Games/Portfolio navigation)

--- a/nextjs-site/next.config.js
+++ b/nextjs-site/next.config.js
@@ -1,6 +1,16 @@
 /** @type {import('next').NextConfig} */
+const isGithubActions = process.env.GITHUB_ACTIONS === 'true';
+const repoName = 'yizijun-site';
+
 const nextConfig = {
   reactStrictMode: true,
+  output: 'export',
+  images: {
+    unoptimized: true,
+  },
+  trailingSlash: true,
+  basePath: isGithubActions ? `/${repoName}` : '',
+  assetPrefix: isGithubActions ? `/${repoName}/` : '',
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
## Summary
Implements issue #71 by removing the Docker-based CD path and replacing it with a simpler GitHub Pages deployment workflow.

### Changes
- Replaced `.github/workflows/cd.yml` with a GitHub Pages deployment pipeline:
  - build static site from `nextjs-site/`
  - upload `nextjs-site/out`
  - deploy via `actions/deploy-pages`
- Updated `nextjs-site/next.config.js` for Pages compatibility:
  - `output: 'export'`
  - `images.unoptimized: true`
  - `trailingSlash: true`
  - repo base path and asset prefix when running in GitHub Actions
- Updated `nextjs-site/README.md` with Pages deployment notes and required repo settings.

## Notes
- This PR intentionally removes Docker/GHCR deployment from CD to keep deployment path minimal for this site.

Closes #71
