### PR TITLE
feat(theme): unify surface depth and hover elevation

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -15,6 +15,9 @@
   --color-success: #22c55e;
   --color-danger: #f43f5e;
 
+  --shadow-soft: 0 10px 30px rgba(2, 6, 23, 0.22);
+  --shadow-lift: 0 16px 36px rgba(2, 6, 23, 0.32);
+
   --radius-sm: 8px;
   --radius-md: 12px;
   --radius-lg: 16px;
@@ -122,9 +125,10 @@ a {
 .panel,
 .panel-link,
 .snake-shell {
-  border: 1px solid var(--color-border);
+  border: 1px solid color-mix(in srgb, var(--color-border) 85%, #94a3b8);
   border-radius: var(--radius-md);
   background: var(--color-surface);
+  box-shadow: var(--shadow-soft);
 }
 
 .card-link,
@@ -138,7 +142,7 @@ a {
   font-weight: 700;
   letter-spacing: 0.03em;
   min-width: 170px;
-  transition: transform 0.2s ease, border-color 0.2s ease, background-color 0.2s ease;
+  transition: transform 0.2s ease, border-color 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .card-link:hover,
@@ -146,6 +150,17 @@ a {
   transform: translateY(-2px);
   border-color: var(--color-accent-strong);
   background: color-mix(in srgb, var(--color-surface) 80%, var(--color-accent-strong));
+  box-shadow: var(--shadow-lift);
+}
+
+.panel {
+  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.panel:hover {
+  transform: translateY(-2px);
+  border-color: color-mix(in srgb, var(--color-accent) 70%, var(--color-border));
+  box-shadow: var(--shadow-lift);
 }
 
 .page h1 {


### PR DESCRIPTION
## Summary
- introduce shared surface shadow tokens for cards/panels/snake container
- increase border clarity with subtle mixed border color for dark theme surfaces
- add lift shadow on interactive card links and informational panels for consistent depth cues

## Validation
- Unable to run project lint/build in this environment because npm is not installed (npm: command not found).
- Visual/CSS changes are scoped to src/app/globals.css only.