### PR TITLE
feat(theme): add keyboard-accessible skip link

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -47,6 +47,26 @@ a {
   color: inherit;
 }
 
+.skip-link {
+  position: fixed;
+  top: var(--space-3);
+  left: 50%;
+  transform: translate(-50%, -140%);
+  z-index: 100;
+  padding: var(--space-2) var(--space-4);
+  border: 1px solid var(--color-accent-strong);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface-alt);
+  color: var(--color-text);
+  text-decoration: none;
+  font-weight: 700;
+  transition: transform 0.2s ease;
+}
+
+.skip-link:focus-visible {
+  transform: translate(-50%, 0);
+}
+
 .site-header {
   border-bottom: 1px solid var(--color-border);
   position: sticky;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,6 +11,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en">
       <body>
+        <a className="skip-link" href="#main-content">
+          Skip to main content
+        </a>
         <header className="site-header">
           <nav className="nav" aria-label="Primary">
             <Link className="nav-link" href="/">Home</Link>
@@ -18,7 +21,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             <Link className="nav-link" href="/games">Games</Link>
           </nav>
         </header>
-        <main className="page-shell">{children}</main>
+        <main id="main-content" className="page-shell">
+          {children}
+        </main>
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- add a persistent skip-to-content link that becomes visible on keyboard focus
- wire the link to the main content container via id="main-content"
- style the skip link to match the existing dark theme tokens and focus behavior

## Validation
- Could not run project lint/tests because Node.js/npm are not installed in this environment (npm: command not found).
- Verified changes by reviewing updated src/app/layout.tsx and src/app/globals.css.
