### PR TITLE
feat: project card schema with validated pinned JSON source

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,23 @@ This project deploys with GitHub Actions via `.github/workflows/cd.yml`.
 Repository settings requirement:
 - In **Settings → Pages**, set **Source** to **GitHub Actions**.
 
+## Project card pinned data
+
+Portfolio project cards are sourced from `src/data/projects.pinned.json` in curated order.
+
+Each entry must include these required fields:
+- `title` (string)
+- `impact` (string, one-line impact statement)
+- `role` (string)
+- `link` (string URL)
+
+Optional fields (safe to omit):
+- `stack` (string)
+- `summary` (string)
+- `highlights` (string[])
+
+Validation/parsing is enforced in `src/lib/project-cards.ts`. Invalid or missing required fields fail fast during render/build, so broken entries are caught early.
+
 ## Routes
 
 - `/` Home (WELCOME, Games/Portfolio navigation)

--- a/src/app/portfolio/page.tsx
+++ b/src/app/portfolio/page.tsx
@@ -1,4 +1,5 @@
-import pinnedProjectsRaw from '@/data/pinned-projects.json';
+import pinnedProjectCards from '@/data/projects.pinned.json';
+import { parsePinnedProjectCards } from '@/lib/project-cards';
 
 const highlights = [
   '3+ years shipping production data and backend systems',
@@ -41,43 +42,7 @@ const experience: ExperienceItem[] = [
   },
 ];
 
-type PinnedProject = {
-  title: string;
-  impact: string;
-  role: string;
-  link: string;
-  repo: string;
-  blurb?: string;
-};
-
-function isPinnedProject(value: unknown): value is PinnedProject {
-  if (!value || typeof value !== 'object') return false;
-
-  const candidate = value as Record<string, unknown>;
-
-  return (
-    typeof candidate.title === 'string' &&
-    typeof candidate.impact === 'string' &&
-    typeof candidate.role === 'string' &&
-    typeof candidate.link === 'string' &&
-    typeof candidate.repo === 'string' &&
-    (candidate.blurb === undefined || typeof candidate.blurb === 'string')
-  );
-}
-
-function getPinnedProjects(): PinnedProject[] {
-  if (!Array.isArray(pinnedProjectsRaw)) {
-    throw new Error('Pinned projects JSON must be an array.');
-  }
-
-  const parsed = pinnedProjectsRaw.filter(isPinnedProject);
-
-  if (parsed.length !== pinnedProjectsRaw.length) {
-    throw new Error('Pinned projects JSON contains invalid entries.');
-  }
-
-  return parsed;
-}
+const pinnedProjects = parsePinnedProjectCards(pinnedProjectCards);
 
 type GithubRepoMetadata = {
   full_name: string;
@@ -98,8 +63,6 @@ type ProjectCard = {
 };
 
 async function fetchCuratedProjects(): Promise<{ cards: ProjectCard[]; hasFetchFailure: boolean }> {
-  const pinnedProjects = getPinnedProjects();
-
   const results = await Promise.all(
     pinnedProjects.map(async (item) => {
       try {
@@ -116,7 +79,7 @@ async function fetchCuratedProjects(): Promise<{ cards: ProjectCard[]; hasFetchF
         }
 
         const repo = (await response.json()) as GithubRepoMetadata;
-        const description = item.blurb ?? repo.description ?? 'No description available yet.';
+        const description = item.summary ?? repo.description ?? 'No description available yet.';
 
         return {
           card: {
@@ -124,7 +87,7 @@ async function fetchCuratedProjects(): Promise<{ cards: ProjectCard[]; hasFetchF
             title: item.title,
             link: item.link || repo.html_url,
             description,
-            language: repo.language ?? 'Not specified',
+            language: repo.language ?? item.stack ?? 'Not specified',
             impact: item.impact,
             role: item.role,
           },
@@ -136,8 +99,8 @@ async function fetchCuratedProjects(): Promise<{ cards: ProjectCard[]; hasFetchF
             repo: item.repo,
             title: item.title,
             link: item.link || `https://github.com/${item.repo}`,
-            description: item.blurb ?? 'Project details are temporarily unavailable. View the repository on GitHub.',
-            language: 'Unavailable',
+            description: item.summary ?? 'Project details are temporarily unavailable. View the repository on GitHub.',
+            language: item.stack ?? 'Unavailable',
             impact: item.impact,
             role: item.role,
           },

--- a/src/app/portfolio/page.tsx
+++ b/src/app/portfolio/page.tsx
@@ -44,77 +44,7 @@ const experience: ExperienceItem[] = [
 
 const pinnedProjects = parsePinnedProjectCards(pinnedProjectCards);
 
-type GithubRepoMetadata = {
-  full_name: string;
-  html_url: string;
-  description: string | null;
-  language: string | null;
-  name: string;
-};
-
-type ProjectCard = {
-  repo: string;
-  title: string;
-  link: string;
-  description: string;
-  language: string;
-  impact: string;
-  role: string;
-};
-
-async function fetchCuratedProjects(): Promise<{ cards: ProjectCard[]; hasFetchFailure: boolean }> {
-  const results = await Promise.all(
-    pinnedProjects.map(async (item) => {
-      try {
-        const response = await fetch(`https://api.github.com/repos/${item.repo}`, {
-          next: { revalidate: 3600 },
-          headers: {
-            Accept: 'application/vnd.github+json',
-            'User-Agent': 'yizijun-site-projects-section',
-          },
-        });
-
-        if (!response.ok) {
-          throw new Error(`GitHub fetch failed for ${item.repo}: ${response.status}`);
-        }
-
-        const repo = (await response.json()) as GithubRepoMetadata;
-        const description = item.summary ?? repo.description ?? 'No description available yet.';
-
-        return {
-          card: {
-            repo: item.repo,
-            title: item.title,
-            link: item.link || repo.html_url,
-            description,
-            language: repo.language ?? item.stack ?? 'Not specified',
-            impact: item.impact,
-            role: item.role,
-          },
-          fetchFailed: false,
-        };
-      } catch {
-        return {
-          card: {
-            repo: item.repo,
-            title: item.title,
-            link: item.link || `https://github.com/${item.repo}`,
-            description: item.summary ?? 'Project details are temporarily unavailable. View the repository on GitHub.',
-            language: item.stack ?? 'Unavailable',
-            impact: item.impact,
-            role: item.role,
-          },
-          fetchFailed: true,
-        };
-      }
-    }),
-  );
-
-  return {
-    cards: results.map((result) => result.card),
-    hasFetchFailure: results.some((result) => result.fetchFailed),
-  };
-}
+const projectCards = pinnedProjects;
 
 const skills = {
   languages: ['Python', 'Java', 'SQL', 'Bash'],
@@ -123,8 +53,7 @@ const skills = {
   dataMl: ['Spark', 'Airflow', 'Elasticsearch', 'Pandas', 'NumPy', 'PyTorch', 'scikit-learn', 'Transformers/Embeddings'],
 };
 
-export default async function PortfolioPage() {
-  const { cards: projectCards, hasFetchFailure } = await fetchCuratedProjects();
+export default function PortfolioPage() {
 
   return (
     <section className="page resume-page">
@@ -174,23 +103,26 @@ export default async function PortfolioPage() {
       <div id="projects" className="resume-section">
         <h2>Projects</h2>
         <p className="resume-meta">Curated repositories selected for recruiter-friendly scanning.</p>
-        {hasFetchFailure ? (
-          <p className="resume-note" role="status">
-            Some live GitHub metadata could not be loaded. Showing fallback project details.
-          </p>
-        ) : null}
         {projectCards.map((project) => (
-          <article className="panel" key={project.repo}>
+          <article className="panel" key={project.title}>
             <h3>{project.title}</h3>
-            <p>{project.description}</p>
             <p className="resume-meta">Impact: {project.impact}</p>
-            <p className="resume-meta">Role: {project.role}</p>
-            <p className="resume-meta">Tech/Language: {project.language}</p>
-            <p>
+            <p className="resume-meta">
+              Role: {project.role}
+              {' · '}
               <a href={project.link} target="_blank" rel="noreferrer">
-                View on GitHub
+                Project link
               </a>
             </p>
+            {project.stack ? <p className="resume-meta">Stack: {project.stack}</p> : null}
+            {project.summary ? <p>{project.summary}</p> : null}
+            {project.highlights && project.highlights.length > 0 ? (
+              <ul className="resume-list">
+                {project.highlights.map((highlight) => (
+                  <li key={highlight}>{highlight}</li>
+                ))}
+              </ul>
+            ) : null}
           </article>
         ))}
       </div>

--- a/src/data/projects.pinned.json
+++ b/src/data/projects.pinned.json
@@ -1,0 +1,14 @@
+[
+  {
+    "title": "Bakery Demand Forecasting System",
+    "impact": "Delivered real-time demand predictions to improve daily inventory planning accuracy.",
+    "role": "Full-stack ML Engineer",
+    "link": "https://github.com/jimzijun",
+    "stack": "Python, Streamlit, Square API, Time-series modeling",
+    "summary": "Designed a fault-tolerant workflow that ingests live transactions and serves operational forecasts.",
+    "highlights": [
+      "Ingested and normalized live POS data",
+      "Served near real-time demand forecasts for planning"
+    ]
+  }
+]

--- a/src/lib/project-cards.ts
+++ b/src/lib/project-cards.ts
@@ -1,0 +1,77 @@
+export type ProjectCard = {
+  title: string;
+  impact: string;
+  role: string;
+  link: string;
+  stack?: string;
+  summary?: string;
+  highlights?: string[];
+};
+
+function isString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every(isString);
+}
+
+export function parsePinnedProjectCards(raw: unknown): ProjectCard[] {
+  if (!Array.isArray(raw)) {
+    throw new Error('Pinned project data must be an array.');
+  }
+
+  return raw.map((item, index) => {
+    if (!item || typeof item !== 'object') {
+      throw new Error(`Project at index ${index} must be an object.`);
+    }
+
+    const card = item as Record<string, unknown>;
+
+    if (!isString(card.title)) {
+      throw new Error(`Project at index ${index} is missing required field: title.`);
+    }
+
+    if (!isString(card.impact)) {
+      throw new Error(`Project \"${card.title}\" is missing required field: impact.`);
+    }
+
+    if (!isString(card.role)) {
+      throw new Error(`Project \"${card.title}\" is missing required field: role.`);
+    }
+
+    if (!isString(card.link)) {
+      throw new Error(`Project \"${card.title}\" is missing required field: link.`);
+    }
+
+    const parsed: ProjectCard = {
+      title: card.title,
+      impact: card.impact,
+      role: card.role,
+      link: card.link,
+    };
+
+    if (card.stack !== undefined) {
+      if (!isString(card.stack)) {
+        throw new Error(`Project \"${card.title}\": optional field stack must be a non-empty string.`);
+      }
+      parsed.stack = card.stack;
+    }
+
+    if (card.summary !== undefined) {
+      if (!isString(card.summary)) {
+        throw new Error(`Project \"${card.title}\": optional field summary must be a non-empty string.`);
+      }
+      parsed.summary = card.summary;
+    }
+
+    if (card.highlights !== undefined) {
+      if (!isStringArray(card.highlights)) {
+        throw new Error(`Project \"${card.title}\": optional field highlights must be a string array.`);
+      }
+      parsed.highlights = card.highlights;
+    }
+
+    return parsed;
+  });
+}


### PR DESCRIPTION
## Summary
- add a typed project card schema with required baseline fields (`title`, `impact`, `role`, `link`)
- add safe runtime validation/parsing for pinned JSON project data
- move portfolio projects to curated pinned JSON source with optional fields supported (`stack`, `summary`, `highlights`)
- document how to add/edit pinned project entries in README

## Validation
- npm run lint
- npm run build

Closes #98
