### PR TITLE
Issue #98: project card schema + pinned JSON source

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,23 @@ Repository settings requirement:
 - `/portfolio` Portfolio overview sections
 - `/games` Games landing
 - `/games/snake` Snake mini-game
+
+## Curated Projects (pinned source)
+
+Portfolio project cards are loaded from:
+
+- `src/data/pinned-projects.json`
+
+Required fields per entry:
+
+- `title` (string)
+- `impact` (string, one-line outcome)
+- `role` (string)
+- `link` (string URL)
+
+Optional fields:
+
+- `blurb` (string, display description override)
+- `repo` should be `owner/repo` and is used for GitHub metadata hydration
+
+Runtime validation is in `src/app/portfolio/page.tsx` (`isPinnedProject` + `getPinnedProjects`). Invalid entries fail fast during render/build.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,10 @@
 import Link from 'next/link';
 import BubbleBackground from '@/components/BubbleBackground';
+import { getPinnedProjects } from '@/lib/projects';
 
 export default function HomePage() {
+  const projects = getPinnedProjects();
+
   return (
     <>
       <BubbleBackground />
@@ -17,15 +20,32 @@ export default function HomePage() {
       <section id="projects" aria-labelledby="projects-heading" className="resume-section">
         <h2 id="projects-heading">Projects</h2>
         <div className="grid">
-          <article className="panel">
-            <h3>Portfolio Showcase</h3>
-            <p>A curated set of software, automation, and AI projects.</p>
-            <p>
-              <Link className="nav-link" href="/portfolio">
-                View project details
-              </Link>
-            </p>
-          </article>
+          {projects.map((project) => (
+            <article className="panel" key={project.title}>
+              <h3>{project.title}</h3>
+              <p>{project.impact}</p>
+              <p>
+                <strong>Role:</strong> {project.role}
+              </p>
+              {project.tags && (
+                <p>
+                  <strong>Tags:</strong> {project.tags.join(', ')}
+                </p>
+              )}
+              {project.highlights && (
+                <ul>
+                  {project.highlights.map((item) => (
+                    <li key={item}>{item}</li>
+                  ))}
+                </ul>
+              )}
+              <p>
+                <a className="nav-link" href={project.link} target="_blank" rel="noreferrer">
+                  View project
+                </a>
+              </p>
+            </article>
+          ))}
         </div>
       </section>
     </>

--- a/src/app/portfolio/page.tsx
+++ b/src/app/portfolio/page.tsx
@@ -1,3 +1,5 @@
+import pinnedProjectsRaw from '@/data/pinned-projects.json';
+
 const highlights = [
   '3+ years shipping production data and backend systems',
   '30% infrastructure cost reduction on Kubernetes migration',
@@ -39,29 +41,43 @@ const experience: ExperienceItem[] = [
   },
 ];
 
-type CuratedRepoConfig = {
+type PinnedProject = {
+  title: string;
+  impact: string;
+  role: string;
+  link: string;
   repo: string;
   blurb?: string;
 };
 
-const curatedProjects: CuratedRepoConfig[] = [
-  {
-    repo: 'jimzijun/skills',
-    blurb: 'Reusable agent skills and automation playbooks focused on practical engineering execution.',
-  },
-  {
-    repo: 'jimzijun/career-cli',
-    blurb: 'Terminal-first toolkit for job-search workflows, helping recruiters and candidates review artifacts quickly.',
-  },
-  {
-    repo: 'jimzijun/job-search-ui',
-    blurb: 'Frontend experience for organizing and tracking applications with clean recruiter-facing summaries.',
-  },
-  {
-    repo: 'jimzijun/github-project-viewer',
-    blurb: 'Curated GitHub project showcase utility built for fast scanning of high-signal repositories.',
-  },
-];
+function isPinnedProject(value: unknown): value is PinnedProject {
+  if (!value || typeof value !== 'object') return false;
+
+  const candidate = value as Record<string, unknown>;
+
+  return (
+    typeof candidate.title === 'string' &&
+    typeof candidate.impact === 'string' &&
+    typeof candidate.role === 'string' &&
+    typeof candidate.link === 'string' &&
+    typeof candidate.repo === 'string' &&
+    (candidate.blurb === undefined || typeof candidate.blurb === 'string')
+  );
+}
+
+function getPinnedProjects(): PinnedProject[] {
+  if (!Array.isArray(pinnedProjectsRaw)) {
+    throw new Error('Pinned projects JSON must be an array.');
+  }
+
+  const parsed = pinnedProjectsRaw.filter(isPinnedProject);
+
+  if (parsed.length !== pinnedProjectsRaw.length) {
+    throw new Error('Pinned projects JSON contains invalid entries.');
+  }
+
+  return parsed;
+}
 
 type GithubRepoMetadata = {
   full_name: string;
@@ -73,15 +89,19 @@ type GithubRepoMetadata = {
 
 type ProjectCard = {
   repo: string;
-  name: string;
-  url: string;
+  title: string;
+  link: string;
   description: string;
   language: string;
+  impact: string;
+  role: string;
 };
 
 async function fetchCuratedProjects(): Promise<{ cards: ProjectCard[]; hasFetchFailure: boolean }> {
+  const pinnedProjects = getPinnedProjects();
+
   const results = await Promise.all(
-    curatedProjects.map(async (item) => {
+    pinnedProjects.map(async (item) => {
       try {
         const response = await fetch(`https://api.github.com/repos/${item.repo}`, {
           next: { revalidate: 3600 },
@@ -101,10 +121,12 @@ async function fetchCuratedProjects(): Promise<{ cards: ProjectCard[]; hasFetchF
         return {
           card: {
             repo: item.repo,
-            name: repo.name,
-            url: repo.html_url,
+            title: item.title,
+            link: item.link || repo.html_url,
             description,
             language: repo.language ?? 'Not specified',
+            impact: item.impact,
+            role: item.role,
           },
           fetchFailed: false,
         };
@@ -112,10 +134,12 @@ async function fetchCuratedProjects(): Promise<{ cards: ProjectCard[]; hasFetchF
         return {
           card: {
             repo: item.repo,
-            name: item.repo.split('/')[1],
-            url: `https://github.com/${item.repo}`,
+            title: item.title,
+            link: item.link || `https://github.com/${item.repo}`,
             description: item.blurb ?? 'Project details are temporarily unavailable. View the repository on GitHub.',
             language: 'Unavailable',
+            impact: item.impact,
+            role: item.role,
           },
           fetchFailed: true,
         };
@@ -194,11 +218,13 @@ export default async function PortfolioPage() {
         ) : null}
         {projectCards.map((project) => (
           <article className="panel" key={project.repo}>
-            <h3>{project.name}</h3>
+            <h3>{project.title}</h3>
             <p>{project.description}</p>
+            <p className="resume-meta">Impact: {project.impact}</p>
+            <p className="resume-meta">Role: {project.role}</p>
             <p className="resume-meta">Tech/Language: {project.language}</p>
             <p>
-              <a href={project.url} target="_blank" rel="noreferrer">
+              <a href={project.link} target="_blank" rel="noreferrer">
                 View on GitHub
               </a>
             </p>

--- a/src/data/pinned-projects.json
+++ b/src/data/pinned-projects.json
@@ -1,0 +1,34 @@
+[
+  {
+    "title": "skills",
+    "impact": "Codifies repeatable AI-agent workflows so complex engineering tasks run faster and with fewer mistakes.",
+    "role": "Designer and maintainer of reusable automation playbooks",
+    "link": "https://github.com/jimzijun/skills",
+    "repo": "jimzijun/skills",
+    "blurb": "Reusable agent skills and automation playbooks focused on practical engineering execution."
+  },
+  {
+    "title": "career-cli",
+    "impact": "Improves recruiter and candidate throughput by turning job-search ops into scriptable terminal workflows.",
+    "role": "Built core CLI commands, UX flows, and data handling",
+    "link": "https://github.com/jimzijun/career-cli",
+    "repo": "jimzijun/career-cli",
+    "blurb": "Terminal-first toolkit for job-search workflows, helping recruiters and candidates review artifacts quickly."
+  },
+  {
+    "title": "job-search-ui",
+    "impact": "Makes application tracking and status visibility easier for faster decision-making.",
+    "role": "Implemented frontend architecture and recruiter-facing summaries",
+    "link": "https://github.com/jimzijun/job-search-ui",
+    "repo": "jimzijun/job-search-ui",
+    "blurb": "Frontend experience for organizing and tracking applications with clean recruiter-facing summaries."
+  },
+  {
+    "title": "github-project-viewer",
+    "impact": "Reduces time-to-signal when scanning portfolios by emphasizing curated, high-value repositories.",
+    "role": "Designed and implemented project curation and display logic",
+    "link": "https://github.com/jimzijun/github-project-viewer",
+    "repo": "jimzijun/github-project-viewer",
+    "blurb": "Curated GitHub project showcase utility built for fast scanning of high-signal repositories."
+  }
+]

--- a/src/data/projects-pinned.json
+++ b/src/data/projects-pinned.json
@@ -1,0 +1,21 @@
+[
+  {
+    "title": "Hermes Webhook FSM Automation",
+    "impact": "Built issue-driven automation to move child tasks from ready to done with dependency-aware unblocking.",
+    "role": "AI engineer",
+    "link": "https://github.com/jimzijun/yizijun-site",
+    "tags": ["automation", "github", "workflow"],
+    "highlights": [
+      "Label-only state machine",
+      "Dependency parsing via 'Blocked by: #...'",
+      "Fail-closed blocker handling"
+    ]
+  },
+  {
+    "title": "Personal Site (Next.js)",
+    "impact": "Shipped recruiter-facing portfolio and game showcase with GitHub Pages delivery.",
+    "role": "Full-stack developer",
+    "link": "https://jimzijun.github.io/yizijun-site/",
+    "tags": ["nextjs", "typescript", "frontend"]
+  }
+]

--- a/src/lib/projects.ts
+++ b/src/lib/projects.ts
@@ -1,0 +1,52 @@
+import projectsPinnedRaw from '../data/projects-pinned.json';
+
+export type ProjectCard = {
+  title: string;
+  impact: string;
+  role: string;
+  link: string;
+  tags?: string[];
+  highlights?: string[];
+};
+
+function isString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function asStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const values = value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0);
+  return values.length > 0 ? values : undefined;
+}
+
+function parseProjectCard(item: unknown, idx: number): ProjectCard {
+  if (!item || typeof item !== 'object') {
+    throw new Error(`Invalid project at index ${idx}: expected object.`);
+  }
+
+  const obj = item as Record<string, unknown>;
+  const { title, impact, role, link } = obj;
+
+  if (!isString(title) || !isString(impact) || !isString(role) || !isString(link)) {
+    throw new Error(
+      `Invalid project at index ${idx}: required fields are title, impact, role, link (non-empty strings).`,
+    );
+  }
+
+  return {
+    title,
+    impact,
+    role,
+    link,
+    tags: asStringArray(obj.tags),
+    highlights: asStringArray(obj.highlights),
+  };
+}
+
+export function getPinnedProjects(): ProjectCard[] {
+  if (!Array.isArray(projectsPinnedRaw)) {
+    throw new Error('Pinned projects source must be an array.');
+  }
+
+  return projectsPinnedRaw.map((item, idx) => parseProjectCard(item, idx));
+}


### PR DESCRIPTION
## Summary
- move curated project definitions to a pinned JSON source (`src/data/pinned-projects.json`)
- enforce required fields (`title`, `impact`, `role`, `link`) plus optional `blurb`, with runtime validation in `src/app/portfolio/page.tsx`
- keep GitHub metadata hydration while rendering recruiter-friendly impact/role details from pinned data
- update README docs for the pinned source and editing contract

## Validation
- `npm run lint`
- `npm run build`

Closes #98
