### PR TITLE
feat: basic SEO metadata pass for recruiter-facing pages

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,8 +3,27 @@ import Link from 'next/link';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
-  title: "Yizijun's Website",
-  description: 'Recreated with Next.js',
+  metadataBase: new URL('https://jimzijun.github.io/yizijun-site'),
+  title: {
+    default: 'Zijun Yi | AI Engineer',
+    template: '%s | Zijun Yi',
+  },
+  description:
+    'AI Engineer focused on production agents, backend automation, and reliable ML systems. Explore projects, portfolio highlights, and contact options.',
+  openGraph: {
+    type: 'website',
+    title: 'Zijun Yi | AI Engineer',
+    description:
+      'Production-ready AI systems, automation workflows, and recruiter-focused project proof from Zijun Yi.',
+    url: 'https://jimzijun.github.io/yizijun-site',
+    siteName: 'Zijun Yi Portfolio',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Zijun Yi | AI Engineer',
+    description:
+      'Production-ready AI systems, automation workflows, and recruiter-focused project proof from Zijun Yi.',
+  },
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,19 @@
+import type { Metadata } from 'next';
 import Link from 'next/link';
 import BubbleBackground from '@/components/BubbleBackground';
 import { getPinnedProjects } from '@/lib/projects';
+
+export const metadata: Metadata = {
+  title: 'Home',
+  description:
+    'AI Engineer portfolio homepage with recruiter-focused value proposition, project proof, and direct contact channels.',
+  openGraph: {
+    title: 'Zijun Yi | AI Engineer Portfolio',
+    description:
+      'Explore shipped AI and automation work, then connect via email, Calendly, or LinkedIn.',
+    url: 'https://jimzijun.github.io/yizijun-site',
+  },
+};
 
 export default function HomePage() {
   const projects = getPinnedProjects();

--- a/src/app/portfolio/page.tsx
+++ b/src/app/portfolio/page.tsx
@@ -1,5 +1,18 @@
+import type { Metadata } from 'next';
 import pinnedProjectCards from '@/data/projects.pinned.json';
 import { parsePinnedProjectCards } from '@/lib/project-cards';
+
+export const metadata: Metadata = {
+  title: 'Portfolio',
+  description:
+    'Portfolio and resume highlights for AI Engineer roles: production systems, reliability metrics, and project proof.',
+  openGraph: {
+    title: 'Portfolio | Zijun Yi',
+    description:
+      'Production reliability, shipped AI workflows, and recruiter-facing project outcomes from Zijun Yi.',
+    url: 'https://jimzijun.github.io/yizijun-site/portfolio',
+  },
+};
 
 const highlights = [
   '3+ years shipping production data and backend systems',


### PR DESCRIPTION
## Summary
- upgrade global metadata with role-aligned title template and recruiter-focused description
- add OpenGraph + Twitter card metadata for homepage discovery and preview quality
- add page-level metadata for Home and Portfolio with specific title/description/OG URLs

## Validation
- npm run lint
- npm run build

Closes #104
