### PR TITLE
feat: CTA analytics endpoint + contact CTA tracking

### DIFF
--- a/src/app/api/cta-click/route.ts
+++ b/src/app/api/cta-click/route.ts
@@ -1,0 +1,82 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+type CtaEventPayload = {
+  ctaId: string;
+  placement: string;
+  href: string;
+  ts?: string;
+};
+
+const RATE_WINDOW_MS = 60_000;
+const MAX_EVENTS_PER_WINDOW = 60;
+const eventCounts = new Map<string, { count: number; windowStart: number }>();
+
+function getClientKey(request: NextRequest): string {
+  const forwarded = request.headers.get('x-forwarded-for');
+  if (forwarded) return forwarded.split(',')[0]?.trim() || 'unknown';
+  return request.headers.get('x-real-ip') || 'unknown';
+}
+
+function isRateLimited(clientKey: string): boolean {
+  const now = Date.now();
+  const current = eventCounts.get(clientKey);
+
+  if (!current || now - current.windowStart > RATE_WINDOW_MS) {
+    eventCounts.set(clientKey, { count: 1, windowStart: now });
+    return false;
+  }
+
+  if (current.count >= MAX_EVENTS_PER_WINDOW) return true;
+
+  current.count += 1;
+  eventCounts.set(clientKey, current);
+  return false;
+}
+
+function isValidPayload(payload: unknown): payload is CtaEventPayload {
+  if (!payload || typeof payload !== 'object') return false;
+  const p = payload as Partial<CtaEventPayload>;
+  return (
+    typeof p.ctaId === 'string' &&
+    p.ctaId.length > 0 &&
+    p.ctaId.length <= 64 &&
+    typeof p.placement === 'string' &&
+    p.placement.length > 0 &&
+    p.placement.length <= 64 &&
+    typeof p.href === 'string' &&
+    p.href.length > 0 &&
+    p.href.length <= 500
+  );
+}
+
+export async function POST(request: NextRequest) {
+  const contentType = request.headers.get('content-type') || '';
+  if (!contentType.toLowerCase().includes('application/json')) {
+    return NextResponse.json({ error: 'content-type must be application/json' }, { status: 415 });
+  }
+
+  const clientKey = getClientKey(request);
+  if (isRateLimited(clientKey)) {
+    return NextResponse.json({ error: 'rate limit exceeded' }, { status: 429 });
+  }
+
+  let payload: unknown;
+  try {
+    payload = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'invalid json body' }, { status: 400 });
+  }
+
+  if (!isValidPayload(payload)) {
+    return NextResponse.json({ error: 'invalid payload' }, { status: 400 });
+  }
+
+  console.info('[cta-click]', {
+    ...payload,
+    receivedAt: new Date().toISOString(),
+    clientKey,
+    userAgent: request.headers.get('user-agent') || 'unknown',
+  });
+
+  return NextResponse.json({ ok: true }, { status: 202 });
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import BubbleBackground from '@/components/BubbleBackground';
+import CTAEventLink from '@/components/CTAEventLink';
 import { getHybridProjects } from '@/lib/projects';
 
 export const metadata: Metadata = {
@@ -21,7 +22,9 @@ export default async function HomePage() {
   return (
     <>
       <BubbleBackground />
-      <a className="sticky-contact-cta" href="#contact">Contact Jim</a>
+      <CTAEventLink className="sticky-contact-cta" href="#contact" ctaId="contact-jim-sticky" placement="sticky">
+        Contact Jim
+      </CTAEventLink>
 
       <section className="hero hero--foreground recruiter-hero" aria-labelledby="home-hero-heading">
         <p className="hero-eyebrow">Open to AI Engineer opportunities</p>
@@ -32,7 +35,9 @@ export default async function HomePage() {
         </p>
         <div className="cta-row">
           <Link className="card-link" href="/portfolio">View AI Project Proof</Link>
-          <a className="card-link" href="#contact">Contact Jim</a>
+          <CTAEventLink className="card-link" href="#contact" ctaId="contact-jim-hero" placement="hero">
+            Contact Jim
+          </CTAEventLink>
         </div>
       </section>
 
@@ -73,27 +78,37 @@ export default async function HomePage() {
         <h2 id="contact-heading">Contact</h2>
         <p className="lead contact-intro">Best for recruiter outreach, interview loops, and collaboration discussions.</p>
         <div className="contact-actions">
-          <a className="card-link" href="mailto:yizijuny@gmail.com" aria-label="Email Jim at yizijuny@gmail.com">
+          <CTAEventLink
+            className="card-link"
+            href="mailto:yizijuny@gmail.com"
+            aria-label="Email Jim at yizijuny@gmail.com"
+            ctaId="contact-email"
+            placement="contact-panel"
+          >
             Email
-          </a>
-          <a
+          </CTAEventLink>
+          <CTAEventLink
             className="card-link"
             href="https://calendly.com/yizijuny"
             target="_blank"
             rel="noreferrer"
             aria-label="Book time with Jim on Calendly"
+            ctaId="contact-calendly"
+            placement="contact-panel"
           >
             Calendly
-          </a>
-          <a
+          </CTAEventLink>
+          <CTAEventLink
             className="card-link"
             href="https://www.linkedin.com/in/zijun-yi-03a4382ab"
             target="_blank"
             rel="noreferrer"
             aria-label="Open Jim's LinkedIn profile"
+            ctaId="contact-linkedin"
+            placement="contact-panel"
           >
             LinkedIn
-          </a>
+          </CTAEventLink>
         </div>
       </section>
 

--- a/src/components/CTAEventLink.tsx
+++ b/src/components/CTAEventLink.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import type { AnchorHTMLAttributes, MouseEvent } from 'react';
+
+type CTAEventLinkProps = AnchorHTMLAttributes<HTMLAnchorElement> & {
+  ctaId: string;
+  placement: string;
+};
+
+const ANALYTICS_ENDPOINT = '/api/cta-click';
+
+function trackCtaClick(payload: { ctaId: string; placement: string; href: string }) {
+  const body = JSON.stringify({
+    ...payload,
+    ts: new Date().toISOString(),
+  });
+
+  try {
+    if (typeof navigator !== 'undefined' && typeof navigator.sendBeacon === 'function') {
+      const blob = new Blob([body], { type: 'application/json' });
+      navigator.sendBeacon(ANALYTICS_ENDPOINT, blob);
+      return;
+    }
+
+    void fetch(ANALYTICS_ENDPOINT, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body,
+      keepalive: true,
+    }).catch(() => undefined);
+  } catch {
+    // never block navigation if analytics fails
+  }
+}
+
+export default function CTAEventLink({ ctaId, placement, href = '', onClick, ...props }: CTAEventLinkProps) {
+  const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
+    onClick?.(event);
+    if (event.defaultPrevented) return;
+
+    trackCtaClick({
+      ctaId,
+      placement,
+      href: String(href),
+    });
+  };
+
+  return <a {...props} href={href} onClick={handleClick} />;
+}


### PR DESCRIPTION
## Summary
- add `/api/cta-click` POST endpoint for internal CTA analytics collection
- add lightweight abuse/error handling (JSON content-type check, payload validation, per-client rate limit)
- wire sticky/hero/contact panel recruiter CTAs to non-blocking client-side analytics events

## Validation
- npm run lint
- npm run build

Closes #103
