### PR TITLE
feat: hybrid recruiter project pipeline (curated + recent)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import BubbleBackground from '@/components/BubbleBackground';
-import { getPinnedProjects } from '@/lib/projects';
+import { getHybridProjects } from '@/lib/projects';
 
 export const metadata: Metadata = {
   title: 'Home',
@@ -15,8 +15,8 @@ export const metadata: Metadata = {
   },
 };
 
-export default function HomePage() {
-  const projects = getPinnedProjects();
+export default async function HomePage() {
+  const projects = await getHybridProjects('jimzijun');
 
   return (
     <>
@@ -68,20 +68,6 @@ export default function HomePage() {
         </div>
       </section>
 
-      <section id="projects" aria-labelledby="projects-heading" className="resume-section">
-        <h2 id="projects-heading">Projects</h2>
-        <div className="grid">
-          <article className="panel">
-            <h3>Portfolio Showcase</h3>
-            <p>A curated set of software, automation, and AI projects.</p>
-            <p>
-              <Link className="nav-link" href="/portfolio">
-                View project details
-              </Link>
-            </p>
-          </article>
-        </div>
-      </section>
 
       <section id="contact" aria-labelledby="contact-heading" className="resume-section contact-section panel">
         <h2 id="contact-heading">Contact</h2>
@@ -117,16 +103,20 @@ export default function HomePage() {
           {projects.map((project) => (
             <article className="panel" key={project.title}>
               <h3>{project.title}</h3>
-              <p>{project.impact}</p>
+              <p>{project.description}</p>
               <p>
                 <strong>Role:</strong> {project.role}
               </p>
-              {project.tags && (
+              <p>
+                <strong>Tech/Language:</strong> {project.language}
+              </p>
+              <p className="resume-meta">{project.impact}</p>
+              {project.tags && project.tags.length > 0 && (
                 <p>
                   <strong>Tags:</strong> {project.tags.join(', ')}
                 </p>
               )}
-              {project.highlights && (
+              {project.highlights && project.highlights.length > 0 && (
                 <ul>
                   {project.highlights.map((item) => (
                     <li key={item}>{item}</li>
@@ -135,7 +125,7 @@ export default function HomePage() {
               )}
               <p>
                 <a className="nav-link" href={project.link} target="_blank" rel="noreferrer">
-                  View project
+                  View on GitHub
                 </a>
               </p>
             </article>

--- a/src/data/projects-pinned.json
+++ b/src/data/projects-pinned.json
@@ -1,21 +1,38 @@
 [
   {
-    "title": "Hermes Webhook FSM Automation",
-    "impact": "Built issue-driven automation to move child tasks from ready to done with dependency-aware unblocking.",
-    "role": "AI engineer",
-    "link": "https://github.com/jimzijun/yizijun-site",
-    "tags": ["automation", "github", "workflow"],
-    "highlights": [
-      "Label-only state machine",
-      "Dependency parsing via 'Blocked by: #...'",
-      "Fail-closed blocker handling"
-    ]
+    "repo": "jimzijun/skills",
+    "title": "Hermes Agent Skills Library",
+    "impact": "Codified reusable agent workflows to accelerate issue-to-PR delivery and reduce repeated manual debugging.",
+    "role": "AI Engineer",
+    "link": "https://github.com/jimzijun/skills",
+    "blurb": "A production-oriented skill library for structured agent execution, debugging, and automation workflows.",
+    "tags": ["agentic-ai", "automation", "developer-productivity"]
   },
   {
-    "title": "Personal Site (Next.js)",
-    "impact": "Shipped recruiter-facing portfolio and game showcase with GitHub Pages delivery.",
-    "role": "Full-stack developer",
-    "link": "https://jimzijun.github.io/yizijun-site/",
-    "tags": ["nextjs", "typescript", "frontend"]
+    "repo": "jimzijun/career-cli",
+    "title": "Career CLI",
+    "impact": "Improved personal job-search execution by turning repetitive application tasks into scriptable terminal workflows.",
+    "role": "Builder",
+    "link": "https://github.com/jimzijun/career-cli",
+    "blurb": "CLI tooling for structured job-tracking, outreach workflows, and application operations.",
+    "tags": ["cli", "python", "job-search"]
+  },
+  {
+    "repo": "jimzijun/job-search-ui",
+    "title": "Job Search UI",
+    "impact": "Created a recruiter-facing and candidate-facing interface for tracking opportunities and progress transparently.",
+    "role": "Full-stack Engineer",
+    "link": "https://github.com/jimzijun/job-search-ui",
+    "blurb": "Web UI for managing opportunities, status funnels, and career pipeline visibility.",
+    "tags": ["frontend", "react", "workflow"]
+  },
+  {
+    "repo": "jimzijun/github-project-viewer",
+    "title": "GitHub Project Viewer",
+    "impact": "Built quick-glance portfolio surfacing for repositories and project metadata to improve recruiter scanning.",
+    "role": "Full-stack Engineer",
+    "link": "https://github.com/jimzijun/github-project-viewer",
+    "blurb": "A lightweight project browser for GitHub repositories with metadata-focused presentation.",
+    "tags": ["github-api", "portfolio", "typescript"]
   }
 ]

--- a/src/lib/projects.ts
+++ b/src/lib/projects.ts
@@ -1,12 +1,34 @@
 import projectsPinnedRaw from '../data/projects-pinned.json';
 
-export type ProjectCard = {
+export type CuratedProject = {
+  repo: string;
   title: string;
   impact: string;
   role: string;
   link: string;
+  blurb?: string;
+  tags?: string[];
+};
+
+export type ProjectCard = {
+  repo?: string;
+  title: string;
+  impact: string;
+  role: string;
+  link: string;
+  description: string;
+  language: string;
   tags?: string[];
   highlights?: string[];
+};
+
+type GithubRepoMetadata = {
+  full_name: string;
+  html_url: string;
+  description: string | null;
+  language: string | null;
+  pushed_at: string;
+  name: string;
 };
 
 function isString(value: unknown): value is string {
@@ -19,34 +41,107 @@ function asStringArray(value: unknown): string[] | undefined {
   return values.length > 0 ? values : undefined;
 }
 
-function parseProjectCard(item: unknown, idx: number): ProjectCard {
+function parseCuratedProject(item: unknown, idx: number): CuratedProject {
   if (!item || typeof item !== 'object') {
     throw new Error(`Invalid project at index ${idx}: expected object.`);
   }
 
   const obj = item as Record<string, unknown>;
-  const { title, impact, role, link } = obj;
+  const { repo, title, impact, role, link } = obj;
 
-  if (!isString(title) || !isString(impact) || !isString(role) || !isString(link)) {
+  if (!isString(repo) || !isString(title) || !isString(impact) || !isString(role) || !isString(link)) {
     throw new Error(
-      `Invalid project at index ${idx}: required fields are title, impact, role, link (non-empty strings).`,
+      `Invalid project at index ${idx}: required fields are repo, title, impact, role, link (non-empty strings).`,
     );
   }
 
   return {
+    repo,
     title,
     impact,
     role,
     link,
+    blurb: isString(obj.blurb) ? obj.blurb : undefined,
     tags: asStringArray(obj.tags),
-    highlights: asStringArray(obj.highlights),
   };
 }
 
-export function getPinnedProjects(): ProjectCard[] {
+export function getPinnedProjects(): CuratedProject[] {
   if (!Array.isArray(projectsPinnedRaw)) {
     throw new Error('Pinned projects source must be an array.');
   }
 
-  return projectsPinnedRaw.map((item, idx) => parseProjectCard(item, idx));
+  return projectsPinnedRaw.map((item, idx) => parseCuratedProject(item, idx));
+}
+
+async function fetchRepo(repo: string): Promise<GithubRepoMetadata | null> {
+  try {
+    const response = await fetch(`https://api.github.com/repos/${repo}`, {
+      next: { revalidate: 3600 },
+      headers: {
+        Accept: 'application/vnd.github+json',
+        'User-Agent': 'yizijun-site-projects-section',
+      },
+    });
+
+    if (!response.ok) return null;
+    return (await response.json()) as GithubRepoMetadata;
+  } catch {
+    return null;
+  }
+}
+
+async function fetchRecentRepos(owner: string): Promise<GithubRepoMetadata[]> {
+  try {
+    const response = await fetch(`https://api.github.com/users/${owner}/repos?sort=pushed&per_page=20`, {
+      next: { revalidate: 3600 },
+      headers: {
+        Accept: 'application/vnd.github+json',
+        'User-Agent': 'yizijun-site-projects-section',
+      },
+    });
+    if (!response.ok) return [];
+    return (await response.json()) as GithubRepoMetadata[];
+  } catch {
+    return [];
+  }
+}
+
+export async function getHybridProjects(owner = 'jimzijun'): Promise<ProjectCard[]> {
+  const curated = getPinnedProjects();
+
+  const curatedResolved = await Promise.all(
+    curated.map(async (project): Promise<ProjectCard> => {
+      const repoMeta = await fetchRepo(project.repo);
+      return {
+        repo: project.repo,
+        title: project.title,
+        impact: project.impact,
+        role: project.role,
+        link: project.link || repoMeta?.html_url || `https://github.com/${project.repo}`,
+        description: project.blurb ?? repoMeta?.description ?? 'Project description unavailable.',
+        language: repoMeta?.language ?? 'Not specified',
+        tags: project.tags,
+      };
+    }),
+  );
+
+  const curatedSet = new Set(curated.map((p) => p.repo.toLowerCase()));
+  const recentRepos = await fetchRecentRepos(owner);
+
+  const recentCards: ProjectCard[] = recentRepos
+    .filter((repo) => !curatedSet.has(repo.full_name.toLowerCase()))
+    .sort((a, b) => new Date(b.pushed_at).getTime() - new Date(a.pushed_at).getTime())
+    .slice(0, 6)
+    .map((repo) => ({
+      repo: repo.full_name,
+      title: repo.name,
+      impact: 'Recent repository activity from GitHub.',
+      role: 'Builder',
+      link: repo.html_url,
+      description: repo.description ?? 'No description available.',
+      language: repo.language ?? 'Not specified',
+    }));
+
+  return [...curatedResolved, ...recentCards];
 }


### PR DESCRIPTION
## Summary
- add curated project config for approved repos in fixed order with optional blurb overrides
- implement hybrid ingestion: curated projects first, then auto-sourced recent repos sorted by recency
- merge strategy: local blurb override wins, fallback to GitHub description, graceful field fallbacks
- update homepage projects UI to show recruiter-focused cards: name, description/blurb, tech/language, and GitHub link
- remove duplicate projects section and polish card readability for responsive recruiter scanning

## Validation
- npm run lint
- npm run build

Closes #91
Closes #92
Closes #93
Closes #94
Closes #101
